### PR TITLE
Added support for setting conditions on resources

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -110,6 +110,24 @@ Or you can extract the "id" parameter as well:
 
 Whatever blows your hair back.
 
+Both the resource and member methods support the usual Sinatra conditions you can set on get, post, put and
+delete. If you specify conditions on a lower resource, like e.g. a different accept type using the :provides
+options, it will overwrite any settings of the parent resource.
+
+  resource :posts, :provides => 'json' do
+    get '/', :provides => 'html' do
+      # only accepts html, not json
+    end
+
+    get '/all' do
+      # only accepts json
+    end
+
+    member :comments, :provides => 'xml' do
+      # subsequent routes will only accept xml
+    end
+  end
+
 == Author
 
 Copyright (c) 2010 {Nate Wiger}[http://nate.wiger.org].  All Rights Reserved.

--- a/README.rdoc
+++ b/README.rdoc
@@ -111,7 +111,13 @@ Or you can extract the "id" parameter as well:
 Whatever blows your hair back.
 
 Both the resource and member methods support the usual Sinatra conditions you can set on get, post, put and
-delete. If you specify conditions on a lower resource, like e.g. a different accept type using the :provides
+delete, so you only have to set them once, and not repeatedly for every route.
+
+  resource :posts, :provides => 'json' do
+    # every nested route will only accept json
+  end
+
+If you specify conditions on a lower resource, like e.g. a different accept type using the :provides
 options, it will overwrite any settings of the parent resource.
 
   resource :posts, :provides => 'json' do

--- a/test/sinatra_resources_test.rb
+++ b/test/sinatra_resources_test.rb
@@ -81,7 +81,11 @@ class RoutingTest < Test::Unit::TestCase
 
     get '/foo'
     assert_equal 404, status
-    assert_equal 'text/html', response["Content-Type"]
+    if Sinatra::VERSION >= "1.1"
+      assert_equal 'text/html;charset=utf-8', response["Content-Type"]
+    else
+      assert_equal 'text/html', response["Content-Type"]
+    end
     assert_equal "<h1>Not Found</h1>", response.body
   end
 

--- a/test/sinatra_resources_test.rb
+++ b/test/sinatra_resources_test.rb
@@ -956,22 +956,61 @@ class RoutingTest < Test::Unit::TestCase
     assert_equal 'bar in subclass', body
   end
 
-  # broken in old Sinatras (not our problem)
-  # it "matches routes in subclasses before superclasses" do
-  #   base = Class.new(Sinatra::Base)
-  #   base.get('/foo') { 'foo in baseclass' }
-  #   base.get('/bar') { 'bar in baseclass' }
-  # 
-  #   mock_app(base) {
-  #     get('/foo') { 'foo in subclass' }
-  #   }
-  # 
-  #   get '/foo'
-  #   assert ok?
-  #   assert_equal 'foo in subclass', body
-  # 
-  #   get '/bar'
-  #   assert ok?
-  #   assert_equal 'bar in baseclass', body
-  # end
+
+  it "supports conditions on resources" do
+    mock_app {
+      resource :admin, :provides => 'json' do
+        resource :users do
+          get do
+            '{"json": true}'
+          end
+        end
+      end
+    }
+
+    header "Accept", "text/html"
+    get '/admin/users'
+    assert last_response.not_found?
+
+    header "Accept", "application/json"
+    get '/admin/users'
+    assert_equal '{"json": true}', last_response.body
+  end
+
+  it "should overwrite parent conditions" do
+    mock_app {
+      resource :admin, :provides => 'json' do
+        resource :users, :provides => 'html' do
+          get do
+            'html'
+          end
+
+          get '/list', :provides => 'json' do
+            '{"json": true}'
+          end
+
+          member :provides => 'json' do
+            get do
+              '{"member": true}'
+            end
+          end
+        end
+      end
+    }
+
+    header "Accept", "text/html"
+    get '/admin/users'
+    assert last_response.ok?
+    assert_equal 'html', last_response.body
+
+    header "Accept", "application/json"
+    get '/admin/users/list'
+    assert last_response.ok?
+    assert_equal '{"json": true}', last_response.body
+
+    header "Accept", "application/json"
+    get '/admin/users/1'
+    assert last_response.ok?
+    assert_equal '{"member": true}', last_response.body
+  end
 end


### PR DESCRIPTION
To build an API I wanted to not repeat a condition to e.g. accept only JSON on every nested route of a resource, so I added support to specify them on a resource. Nested conditions will take higher priority, so a nested resource with a different condition than the parent will overwrite that setting. Hope this is useful to someone else.
